### PR TITLE
Add Dockerfile for dlayer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.git
+.dockerignore
+Dockerfile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM golang:1.13.4-alpine3.10 AS builder
+
+WORKDIR /go/src/app
+COPY . .
+
+ENV CGO_ENABLED=0 GOOS=linux
+
+RUN go get -d -v ./...
+RUN go install -v ./...
+
+FROM scratch
+
+COPY --from=builder /go/bin/dlayer /bin/dlayer
+
+ENTRYPOINT ["/bin/dlayer"]


### PR DESCRIPTION
Hi!

I'd like to ask you to add Dockerfile and publish it on docker hub.

I confirmed this Dockerfile can be built successfully:

```
$ docker build . -t dlayer && docker save busybox | docker run -i dlayer -n 5 
Sending build context to Docker daemon  18.94kB
Step 1/9 : FROM golang:1.13.4-alpine3.10 AS builder
 ---> 3024b4e742b0
Step 2/9 : WORKDIR /go/src/app
 ---> Using cache
 ---> aa1b0c650d33
Step 3/9 : COPY . .
 ---> Using cache
 ---> 0f66a6b62cbd
Step 4/9 : ENV CGO_ENABLED=0 GOOS=linux
 ---> Using cache
 ---> 32c68e71176c
Step 5/9 : RUN go get -d -v ./...
 ---> Using cache
 ---> a2f730fdd5d1
Step 6/9 : RUN go install -v ./...
 ---> Using cache
 ---> 0830003d39ec
Step 7/9 : FROM scratch
 ---> 
Step 8/9 : COPY --from=builder /go/bin/dlayer /bin/dlayer
 ---> Using cache
 ---> 03dc2a1f168f
Step 9/9 : ENTRYPOINT ["/bin/dlayer"]
 ---> Using cache
 ---> 2dd6bab8d761
Successfully built 2dd6bab8d761
Successfully tagged dlayer:latest

====================================================================================================
 1.2 MB 	 $ #(nop) ADD file:9ceca008111a4ddff7a68f2c3b645ff51fd6d70ef79b0a60cd0b006aa7033698 in /
====================================================================================================
 1.1 MB 	 bin/[
  86 kB 	 bin/getconf
  340 B 	 etc/passwd
  307 B 	 etc/group
  136 B 	 etc/shadow
```

What do you think?