### PR TITLE
Fix install instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ dlayer is docker layer analyzer.
 
 ## Installation
 ```bash
-go install github.com/orisano/dlayer$latest
+go install github.com/orisano/dlayer@latest
 ```
 or
 ```

--- a/README.md
+++ b/README.md
@@ -3,8 +3,7 @@ dlayer is docker layer analyzer.
 
 ## Installation
 ```bash
-go install github.com/orisano/dlayer
-# go get github.com/orisano/dlayer
+go install github.com/orisano/dlayer$latest
 ```
 or
 ```


### PR DESCRIPTION
before

```bash
$ go install github.com/orisano/dlayer
go: 'go install' requires a version when current directory is not in a module
	Try 'go install github.com/orisano/dlayer@latest' to install the latest version
```

after

```bash
$ go install github.com/orisano/dlayer@latest
go: downloading github.com/orisano/dlayer v0.3.1
go: downloading github.com/gdamore/tcell/v2 v2.3.1
go: downloading mvdan.cc/sh/v3 v3.3.0
go: downloading github.com/rivo/tview v0.0.0-20210514202809-22dbf8415b04
go: downloading github.com/gdamore/encoding v1.0.0
go: downloading golang.org/x/term v0.0.0-20210503060354-a79de5458b56
go: downloading github.com/mattn/go-runewidth v0.0.12
go: downloading golang.org/x/sys v0.0.0-20210514084401-e8d321eab015
$ dlayer -h
Usage of dlayer:
  -a	show details
  -d int
    	max depth (default 8)
  -f string
    	image.tar path (default "-")
  -i	interactive mode
  -l int
    	screen line width (default 100)
  -n int
    	max files (default 100)
```